### PR TITLE
Increase key font sizes in calculator UI

### DIFF
--- a/comisiones.css
+++ b/comisiones.css
@@ -381,8 +381,8 @@
         .calc-row {
             display: flex;
             justify-content: space-between;
-            padding: 3px 0;
-            font-size: 11px;
+            padding: 4px 0;
+            font-size: 13px;
         }
         
         .calc-row.negative {
@@ -408,7 +408,7 @@
         }
         
         .calc-total-value {
-            font-size: 18px;
+            font-size: 20px;
             font-weight: bold;
             margin-top: 4px;
         }
@@ -499,7 +499,7 @@
         }
         
         .multiplier-title {
-            font-size: 12px;
+            font-size: 14px;
             font-weight: 600;
             text-align: center;
             margin-bottom: 2px;
@@ -509,8 +509,8 @@
         .multiplier-row {
             display: flex;
             justify-content: space-between;
-            padding: 4px 6px;
-            font-size: 12px;
+            padding: 5px 6px;
+            font-size: 13px;
             cursor: pointer;
             border-radius: 2px;
             transition: all 0.2s;
@@ -527,7 +527,7 @@
         
         .multiplier-current {
             text-align: center;
-            font-size: 12px;
+            font-size: 13px;
             margin-top: 4px;
             color: #666;
         }


### PR DESCRIPTION
## Summary
- bump `.calc-row` font and adjust padding
- enlarge `.calc-total-value`
- raise text sizes for multiplier components

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d7d6c2e78832f83f810709b5a2c25