### PR TITLE
Add open sidebar button

### DIFF
--- a/app.js
+++ b/app.js
@@ -618,15 +618,18 @@
             if (statSubtotal) statSubtotal.textContent = formatNumber(subtotal) + ' Gs';
         }
 
-        function toggleSidebar() {
-            const panel = document.querySelector('.left-panel');
-            const btn = document.getElementById('toggleSidebarBtn');
+       function toggleSidebar() {
+           const panel = document.querySelector('.left-panel');
+           const btn = document.getElementById('toggleSidebarBtn');
+            const openBtn = document.getElementById('openSidebarBtn');
             if (panel.classList.contains('collapsed')) {
                 panel.classList.remove('collapsed');
                 btn.textContent = '⬅️ Ocultar';
+                if (openBtn) openBtn.style.display = 'none';
             } else {
                 panel.classList.add('collapsed');
                 btn.textContent = '➡️ Mostrar';
+                if (openBtn) openBtn.style.display = 'block';
             }
         }
         

--- a/comisiones.css
+++ b/comisiones.css
@@ -45,6 +45,20 @@
         .left-panel.collapsed {
             display: none;
         }
+
+        .open-sidebar-btn {
+            position: fixed;
+            top: 10px;
+            left: 10px;
+            z-index: 1000;
+            padding: 6px 10px;
+            background: #006D77;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            display: none;
+        }
         
         .header {
             background: linear-gradient(135deg, #006D77 0%, #83C5BE 100%);

--- a/index.html
+++ b/index.html
@@ -167,7 +167,10 @@
                 </div>
             </div>
         </div>
-        
+
+        <!-- Botón para abrir sidebar -->
+        <button id="openSidebarBtn" class="open-sidebar-btn" onclick="toggleSidebar()">➡️ Mostrar</button>
+
         <!-- Panel Derecho -->
         <div class="right-panel">
             <div class="top-stats">


### PR DESCRIPTION
## Summary
- add a fixed button outside the sidebar to reopen it
- style the new button
- update sidebar toggle logic to show/hide the button

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685d7d445ee8832faaace01a05809a6e