### PR TITLE
Add default quality values

### DIFF
--- a/app.js
+++ b/app.js
@@ -894,6 +894,22 @@
                 });
                 document.getElementById('nivelAnterior').value = '2';
                 document.getElementById('nivelEquipo').value = '1';
+
+                const conv = document.getElementById('conversion');
+                conv.value = '8';
+                conv.classList.add('filled');
+                conv.classList.remove('empty');
+
+                const emp = document.getElementById('empatia');
+                emp.value = '96';
+                emp.classList.add('filled');
+                emp.classList.remove('empty');
+
+                const proc = document.getElementById('proceso');
+                proc.value = '95';
+                proc.classList.add('filled');
+                proc.classList.remove('empty');
+
                 updateCalculations();
             }
         }

--- a/index.html
+++ b/index.html
@@ -104,22 +104,22 @@
                 
                 <div class="input-group">
                     <label>Conversión % <span class="req">*</span></label>
-                    <input type="text" class="input-field required" id="conversion" 
-                           placeholder="Ej: 7" maxlength="5"
+                    <input type="text" class="input-field required" id="conversion"
+                           placeholder="Ej: 7" maxlength="5" value="8"
                            onkeyup="formatAndCalculate(this)">
                 </div>
                 
                 <div class="input-group">
                     <label>Empatía/Mystery % <span class="req">*</span></label>
-                    <input type="text" class="input-field required" id="empatia" 
-                           placeholder="Ej: 92" maxlength="3"
+                    <input type="text" class="input-field required" id="empatia"
+                           placeholder="Ej: 92" maxlength="3" value="96"
                            onkeyup="formatAndCalculate(this)">
                 </div>
                 
                 <div class="input-group">
                     <label>Proceso/CRM % <span class="req">*</span></label>
-                    <input type="text" class="input-field required" id="proceso" 
-                           placeholder="Ej: 85" maxlength="3"
+                    <input type="text" class="input-field required" id="proceso"
+                           placeholder="Ej: 85" maxlength="3" value="95"
                            onkeyup="formatAndCalculate(this)">
                 </div>
                 


### PR DESCRIPTION
## Summary
- set default values for Conversión, Empatía/Mystery and Proceso/CRM inputs
- reset to defaults when clearing form

## Testing
- `node -c app.js`

------
https://chatgpt.com/codex/tasks/task_e_685d7d49739c832f9c10ee89c6a665b6