### PR TITLE
Change default team level to Senior A

### DIFF
--- a/app.js
+++ b/app.js
@@ -897,7 +897,7 @@
                     }
                 });
                 document.getElementById('nivelAnterior').value = '2';
-                document.getElementById('nivelEquipo').value = '1';
+                document.getElementById('nivelEquipo').value = '2';
 
                 const conv = document.getElementById('conversion');
                 conv.value = '8';

--- a/index.html
+++ b/index.html
@@ -157,8 +157,8 @@
                     <label>Menor nivel del equipo</label>
                     <select class="input-field" id="nivelEquipo" onchange="updateCalculations()">
                         <option value="0">Capilla</option>
-                        <option value="1" selected>Junior</option>
-                        <option value="2">Senior A</option>
+                        <option value="1">Junior</option>
+                        <option value="2" selected>Senior A</option>
                         <option value="3">Senior B</option>
                         <option value="4">Máster</option>
                         <option value="5">Genio</option>


### PR DESCRIPTION
## Summary
- default `nivelEquipo` option now shows **Senior A** instead of Junior
- reset function also sets `nivelEquipo` to Senior A

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d83585388832fb5ee1a23ce08072f