### PR TITLE
Improve visual cue for empty required fields

### DIFF
--- a/comisiones.css
+++ b/comisiones.css
@@ -144,6 +144,11 @@
             border-color: #F44336;
             background: #FFEBEE;
         }
+
+        .input-field.required.empty {
+            border-color: #F44336 !important;
+            box-shadow: 0 0 0 2px rgba(244, 67, 54, 0.2);
+        }
         
         .help-text {
             font-size: 10px;


### PR DESCRIPTION
## Summary
- style `.input-field.required.empty` to make empty required fields stand out with a bright red border and subtle shadow

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685d846a789c832f867184dc6b552408