### PR TITLE
Clear draft when resetting form

### DIFF
--- a/app.js
+++ b/app.js
@@ -914,6 +914,9 @@
                 proc.classList.add('filled');
                 proc.classList.remove('empty');
 
+                // Limpiar el localStorage también
+                localStorage.removeItem('draftCommission');
+
                 updateCalculations();
             }
         }


### PR DESCRIPTION
## Summary
- clear `draftCommission` from `localStorage` in `limpiarTodo()` so saved drafts don't persist after wiping form

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d86464be0832f8923d4ef701a2731