### PR TITLE
Fix filled class initialization for weekly key input

### DIFF
--- a/app.js
+++ b/app.js
@@ -1057,8 +1057,15 @@
             });
 
             const menorSemanaInput = document.getElementById('menorSemana');
-            if (menorSemanaInput && menorSemanaInput.value) {
-                menorSemanaInput.classList.add('filled');
+            if (menorSemanaInput) {
+                const valor = parseInt(menorSemanaInput.value, 10);
+                if (!isNaN(valor) && valor >= 2) {
+                    menorSemanaInput.classList.add('filled');
+                    menorSemanaInput.classList.remove('empty');
+                } else {
+                    menorSemanaInput.classList.remove('filled');
+                    menorSemanaInput.classList.add('empty');
+                }
             }
 
             const moraInput = document.getElementById('clientesMora');


### PR DESCRIPTION
## Summary
- check `menorSemana` numeric value in `window.onload`
- only add the `filled` class if the value parsed as integer is `>= 2`

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_685d8726dad0832fa1754b2cb1af9263