### PR TITLE
Remove stored draft after reset

### DIFF
--- a/app.js
+++ b/app.js
@@ -897,6 +897,8 @@
                         input.classList.add('invalid');
                     }
                 });
+                // Limpiar el borrador almacenado
+                localStorage.removeItem('draftCommission');
                 document.getElementById('nivelAnterior').value = '2';
                 document.getElementById('nivelEquipo').value = '2';
 
@@ -914,9 +916,6 @@
                 proc.value = '95';
                 proc.classList.add('filled');
                 proc.classList.remove('empty');
-
-                // Limpiar el localStorage también
-                localStorage.removeItem('draftCommission');
 
                 updateCalculations();
             }


### PR DESCRIPTION
## Summary
- clear draft commission data when cleaning all form inputs

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685d883bbdd8832fb74788b0e10a3964