### PR TITLE
Fix filled status on montoExterno and recuperado

### DIFF
--- a/app.js
+++ b/app.js
@@ -229,8 +229,12 @@
                 document.getElementById('montoInterno').classList.remove('empty');
             } else if (tipo === 'externo') {
                 document.getElementById('montoExterno').value = formatNumber(valor);
+                document.getElementById('montoExterno').classList.add('filled');
+                document.getElementById('montoExterno').classList.remove('empty');
             } else if (tipo === 'recuperado') {
                 document.getElementById('montoRecuperado').value = formatNumber(valor);
+                document.getElementById('montoRecuperado').classList.add('filled');
+                document.getElementById('montoRecuperado').classList.remove('empty');
             } else if (tipo === 'cantidad') {
                 document.getElementById('cantidadDesembolsos').value = valor;
                 document.getElementById('cantidadDesembolsos').classList.add('filled');


### PR DESCRIPTION
## Summary
- keep UI styles consistent when loading preset values
- run `updateCalculations` to confirm the calculator still executes

## Testing
- `npm test` *(fails: could not find package.json)*
- `node run_update.js`

------
https://chatgpt.com/codex/tasks/task_e_685d883d16e4832f81b95fcd56f4217a