### PR TITLE
Add Node.js version requirement and workflow

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,0 +1,18 @@
+name: Node CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: node --version

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ y otros datos relevantes para calcular los pagos según el nivel de cada asesor.
 - Sección de llave semanal y requisitos de calidad.
 - Generación de PDF y opción para limpiar los campos.
 
+## Requisitos
+Se recomienda utilizar **Node.js 18** para desarrollar y ejecutar los scripts de apoyo.
+
 ## Uso
 Abre `index.html` en tu navegador para utilizar la herramienta.
 


### PR DESCRIPTION
## Summary
- mention Node.js 18 in a new "Requisitos" section of the README
- add a GitHub Actions workflow that uses Node.js 18

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_685dd054544c832fa9a49eb467b8fe0e