### PR TITLE
Update README with offline testing note

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,10 @@ y otros datos relevantes para calcular los pagos según el nivel de cada asesor.
 ## Uso
 Abre `index.html` en tu navegador para utilizar la herramienta.
 
+## Pruebas
+La instalación de dependencias con `npm install` requiere acceso a internet.
+Si trabajas sin conexión, configura un registro npm local o incluye un
+directorio `node_modules` previamente poblado para ejecutar las pruebas.
+
 ## Licencia
 Distribuido bajo los términos de la licencia MIT (SPDX: MIT). Consulta el archivo [LICENSE](LICENSE) para más informacion.


### PR DESCRIPTION
## Summary
- add Pruebas section detailing internet requirement for npm install
- recommend using a local npm registry or prepopulated `node_modules` for offline tests

## Testing
- `grep -n "Pruebas" -n README.md`

------
https://chatgpt.com/codex/tasks/task_e_685dd04d8b30832f8f9c971d0c28705f