### PR TITLE
Adjust equipo bonus requirements

### DIFF
--- a/app.js
+++ b/app.js
@@ -617,7 +617,7 @@
             
             // Actualizar info
             const equipoTexto = niveles[nivelEquipo];
-            const cumpleRequisito = nivelCarrera >= 3 && nivelEquipo >= 3;
+            const cumpleRequisito = nivelCarrera >= 2 && nivelEquipo >= 2;
             const bonusEquipo = cumpleRequisito ? pagos.equipo[nivelEquipo] : 0;
             
             info.innerHTML = `Menor nivel del equipo: <strong>${equipoTexto}</strong> | 
@@ -625,13 +625,13 @@
                              Premio: <strong>${formatNumber(bonusEquipo)} Gs</strong>`;
             
             // Actualizar mensaje de requisitos
-            if (nivelCarrera < 3) {
+            if (nivelCarrera < 2) {
                 requisitos.style.display = 'block';
-                requisitos.innerHTML = '⚠️ Necesitas estar en Senior B+ para cobrar premio equipo';
+                requisitos.innerHTML = '⚠️ Necesitas estar en Senior A+ para cobrar premio equipo';
                 requisitos.style.background = '#FFF3E0';
-            } else if (nivelEquipo < 3) {
+            } else if (nivelEquipo < 2) {
                 requisitos.style.display = 'block';
-                requisitos.innerHTML = '⚠️ El equipo necesita estar en Senior B+ para activar premio';
+                requisitos.innerHTML = '⚠️ El equipo necesita estar en Senior A+ para activar premio';
                 requisitos.style.background = '#FFF3E0';
             } else {
                 requisitos.style.display = 'block';
@@ -757,7 +757,7 @@
             const bonusCantidad = info.nivelCantidadLimitado >= 0 ? pagos.cantidad[info.nivelCantidadLimitado] : 0;
         
             let bonusEquipo = 0;
-            if (info.nivelCarrera >= 3 && values.nivelEquipo >= 3) {
+            if (info.nivelCarrera >= 2 && values.nivelEquipo >= 2) {
                 bonusEquipo = pagos.equipo[values.nivelEquipo];
             }
         

--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@
                         <option value="4">Máster</option>
                         <option value="5">Genio</option>
                     </select>
-                    <div class="help-text">Para premio equipo (desde Senior B)</div>
+                    <div class="help-text">Para premio equipo (desde Senior A)</div>
                 </div>
             </div>
         </div>
@@ -224,7 +224,7 @@
                     </div>
                     <div class="progress-info" id="infoEquipo"></div>
                     <div id="equipoRequisitos" style="margin-top: 8px; padding: 8px; background: #FFF3E0; border-radius: 4px; font-size: 11px; color: #E65100;">
-                        ⚠️ Necesitas estar en Senior B+ para cobrar premio equipo
+                        ⚠️ Necesitas estar en Senior A+ para cobrar premio equipo
                     </div>
                 </div>
                 
@@ -320,7 +320,7 @@
                         • <strong>Llaves:</strong> Sin 6 desemb. no hay premio interno | 2/sem habilita premio cantidad
                         <br>• <strong>Multiplicadores:</strong> Se aplican en cadena (Conv × Emp × Proc)
                         <br>• <strong>Base fija:</strong> Siempre 3M, nunca se multiplica
-                        <br>• <strong>Equipo:</strong> Premio según menor nivel del equipo (desde Senior B)
+                        <br>• <strong>Equipo:</strong> Premio según menor nivel del equipo (desde Senior A)
                         <br>• <strong>Meta vs Premio:</strong> Meta = monto a desembolsar | Premio = comisión que ganás
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- loosen equipo bonus requirement to start from Senior A
- show new Senior A+ requirement in help text and warnings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685de91b0bdc832fb7470ece4f9326cd