### PR TITLE
Add llave indicators for montos

### DIFF
--- a/app.js
+++ b/app.js
@@ -740,11 +740,23 @@
             const multiplicadorTotal = updateMultiplicadorTables();
         
             const cumpleLlaveMonto = values.cantidad >= 6;
-            document.getElementById('internoLlave').textContent =
+            document.getElementById('montoLlave').textContent =
                 cumpleLlaveMonto
                     ? 'Llave Montos (Int/Ext/Rec): \u2713 6 desem.'
-                    : 'Llave Montos (Int/Ext/Rec): \u274C Min 6 desem.';
-            document.getElementById('internoLlave').className =
+                    : 'Llave Montos (Int/Ext/Rec): \u274C 6 desem.';
+            document.getElementById('montoLlave').className =
+                cumpleLlaveMonto ? 'llave text-success' : 'llave text-danger';
+            document.getElementById('externoLlave').textContent =
+                cumpleLlaveMonto
+                    ? 'Llave Montos (Int/Ext/Rec): \u2713 6 desem.'
+                    : 'Llave Montos (Int/Ext/Rec): \u274C 6 desem.';
+            document.getElementById('externoLlave').className =
+                cumpleLlaveMonto ? 'llave text-success' : 'llave text-danger';
+            document.getElementById('recuperadoLlave').textContent =
+                cumpleLlaveMonto
+                    ? 'Llave Montos (Int/Ext/Rec): \u2713 6 desem.'
+                    : 'Llave Montos (Int/Ext/Rec): \u274C 6 desem.';
+            document.getElementById('recuperadoLlave').className =
                 cumpleLlaveMonto ? 'llave text-success' : 'llave text-danger';
         
             document.getElementById('internoStatus').textContent = nivelInterno >= 0 ? `\u2713 Nivel: ${niveles[nivelInterno]}` : '';

--- a/index.html
+++ b/index.html
@@ -50,26 +50,32 @@
                            onblur="applyFormat(this)">
                     <div class="status-text">
                         <span id="internoStatus"></span>
-                        <span id="internoLlave" class="llave"></span>
+                        <span id="montoLlave" class="llave"></span>
                     </div>
                 </div>
                 
                 <div class="input-group">
                     <label>Monto Externo/Referenciado</label>
-                    <input type="text" class="input-field" id="montoExterno" 
+                    <input type="text" class="input-field" id="montoExterno"
                            placeholder="Ej: 80.000.000"
                            onkeyup="formatAndCalculate(this)"
                            onfocus="removeFormat(this)"
                            onblur="applyFormat(this)">
+                    <div class="status-text">
+                        <span id="externoLlave" class="llave"></span>
+                    </div>
                 </div>
                 
                 <div class="input-group">
                     <label>Recuperados +3 meses</label>
-                    <input type="text" class="input-field" id="montoRecuperado" 
+                    <input type="text" class="input-field" id="montoRecuperado"
                            placeholder="Ej: 60.000.000"
                            onkeyup="formatAndCalculate(this)"
                            onfocus="removeFormat(this)"
                            onblur="applyFormat(this)">
+                    <div class="status-text">
+                        <span id="recuperadoLlave" class="llave"></span>
+                    </div>
                     <div class="help-text">Clientes recuperados después de 3 meses</div>
                 </div>
                 


### PR DESCRIPTION
## Summary
- rename `internoLlave` span to `montoLlave`
- show llave status for externo and recuperados
- handle new spans in the calculation logic

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_685de954cc4c832fb97c74aabbe10256